### PR TITLE
Consolidate CI steps into rake ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Set rbs collection up
-      run: bundle exec rbs collection install --frozen
-    - name: Run the default task
-      run: bundle exec rake
-    - name: Run rspec
-      run: bundle exec rspec
-    - name: Run rbs validate
-      run: bundle exec rbs validate
-    - name: Run steep
-      run: bundle exec steep check
+    - name: Run CI
+      run: bundle exec rake ci

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,34 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
+RSpec::Core::RakeTask.new(:spec)
 
-task default: :rubocop
+task default: :ci
+
+task ci: %i[rubocop spec steep rbs:validate]
+
+namespace :rbs do
+  desc "Install RBS signatures"
+  task :install do
+    sh "bundle exec rbs collection install --frozen"
+  end
+
+  desc "Generate RBS files"
+  task :generate do
+    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
+  desc "Validate RBS files"
+  task validate: "rbs:install" do
+    sh "bundle exec rbs -Isig validate"
+  end
+end
+
+desc "Run steep type check"
+task steep: "rbs:install" do
+  sh "bundle exec steep check"
+end


### PR DESCRIPTION
## Summary

The CI workflow spelled out each step (`rbs collection install`, `rake`, `rspec`, `rbs validate`, `steep check`) directly in YAML. This moves that logic into the `Rakefile` so `rake ci` is the single source of truth, matching the `init-ruby-project` skeleton and keeping local and CI runs identical. The workflow now just runs `bundle exec rake ci`.

It also changes the bare `rbs validate` to `rbs -Isig validate` so the repo's own signatures under `sig/` are actually validated (the previous invocation only validated core/stdlib/collection).

## Changes

- `Rakefile`
  - add `ci` task: `rubocop spec steep rbs:validate`
  - add `rbs:install` (`rbs collection install --frozen`), `rbs:generate`, `rbs:validate` (`rbs -Isig validate`)
  - `steep` and `rbs:validate` depend on `rbs:install`; rake dedupes prerequisites so the collection installs exactly once per `rake ci`
- `.github/workflows/main.yml`
  - replace the five spelled-out steps with a single `Run CI` step (`bundle exec rake ci`)

## Notes

- Job/check names (`Ruby 3.3` / `3.4` / `4.0`) are preserved.
- Please confirm CI stays green — `-Isig` now validates `sig/`, which was not validated before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)