### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,20 @@
 AllCops:
   TargetRubyVersion: 3.3
 
+plugins:
+  - rubocop-rbs_inline
+
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-rbs_inline"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,10 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     shrine (3.8.0)
@@ -232,6 +236,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-rbs_inline
   steep
 
 BUNDLED WITH

--- a/lib/rbs_shrine/utils.rb
+++ b/lib/rbs_shrine/utils.rb
@@ -12,7 +12,7 @@ module RbsShrine
       end.string
     end
 
-    # @rbs klass_name: singleton(Object)
+    # @rbs klass: singleton(Object)
     def klass_to_names(klass) #: Array[RBS::TypeName]
       type_name = RBS::TypeName.parse("::#{klass.name}")
 

--- a/sig/rbs_shrine/utils.rbs
+++ b/sig/rbs_shrine/utils.rbs
@@ -5,7 +5,7 @@ module RbsShrine
     # @rbs rbs: String
     def format: (String rbs) -> String
 
-    # @rbs klass_name: singleton(Object)
-    def klass_to_names: (untyped klass) -> Array[RBS::TypeName]
+    # @rbs klass: singleton(Object)
+    def klass_to_names: (singleton(Object) klass) -> Array[RBS::TypeName]
   end
 end


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton, so the inline type annotations are checked by `rake rubocop` / `rake ci`.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`
  - add a `plugins` section with `rubocop-rbs_inline`
  - add `Style/RbsInline/*` settings (matching the skeleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)