### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 3.3
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rbs_inline
 
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 gem "rubocop-rbs_inline"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rbs_inline (1.5.5)
       lint_roller (~> 1.1)
       rbs-inline
@@ -236,6 +239,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rbs_inline
   steep
 

--- a/lib/rbs_shrine/shrine.rb
+++ b/lib/rbs_shrine/shrine.rb
@@ -6,7 +6,7 @@ require_relative "utils"
 module RbsShrine
   module Shrine
     def self.all #: Array[singleton(ActiveRecord::Base)]
-      ActiveRecord::Base.descendants.select { |model| model.ancestors.any?(::Shrine::Attachment) }
+      ActiveRecord::Base.descendants.select { _1.ancestors.any?(::Shrine::Attachment) }
     end
 
     # @rbs klass: singleton(ActiveRecord::Base)
@@ -74,7 +74,7 @@ module RbsShrine
       end
 
       def attachments #: Array[::Shrine::Attachment]
-        @klass.ancestors.filter_map { |mod| mod if mod.is_a? ::Shrine::Attachment }
+        @klass.ancestors.filter_map { _1 if _1.is_a? ::Shrine::Attachment }
       end
     end
   end

--- a/rbs_shrine.gemspec
+++ b/rbs_shrine.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)