### PR TITLE
Introduce rubocop-rspec plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ plugins:
   - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
+  - rubocop-rspec
 
 Style/Documentation:
   Enabled: false
@@ -42,3 +43,9 @@ Layout/MethodLength:
 
 Metrics/AbcSize:
   Max: 20
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
+gem "rubocop-rspec"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,10 @@ GEM
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     shrine (3.8.0)
@@ -245,6 +249,7 @@ DEPENDENCIES
   rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
+  rubocop-rspec
   steep
 
 BUNDLED WITH

--- a/spec/rbs_shrine/shrine_spec.rb
+++ b/spec/rbs_shrine/shrine_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RbsShrine::Shrine do
     subject { described_class.all }
 
     it "returns all ActiveRecord models with Shrine::Attachment" do
-      is_expected.to contain_exactly(Account, Article)
+      expect(subject).to contain_exactly(Account, Article)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe RbsShrine::Shrine do
         end
       RBS
 
-      is_expected.to eq(rbs)
+      expect(subject).to eq(rbs)
     end
   end
 end

--- a/spec/rbs_shrine/utils_spec.rb
+++ b/spec/rbs_shrine/utils_spec.rb
@@ -3,7 +3,7 @@
 require "rbs_shrine"
 
 RSpec.describe RbsShrine::Utils do
-  include RbsShrine::Utils
+  include described_class
 
   describe "#klass_to_names" do
     subject { klass_to_names(klass) }
@@ -16,11 +16,11 @@ RSpec.describe RbsShrine::Utils do
     let(:klass_name) { "Foo::Bar::Baz" }
 
     it "returns RBS type names" do
-      is_expected.to eq([
-                          RBS::TypeName.parse("::Foo"),
-                          RBS::TypeName.parse("::Foo::Bar"),
-                          RBS::TypeName.parse("::Foo::Bar::Baz")
-                        ])
+      expect(subject).to eq([
+                              RBS::TypeName.parse("::Foo"),
+                              RBS::TypeName.parse("::Foo::Bar"),
+                              RBS::TypeName.parse("::Foo::Bar::Baz")
+                            ])
     end
   end
 end


### PR DESCRIPTION
Add the `rubocop-rspec` plugin so this repository lints its specs, completing the full plugin set (numbered-params, rake, rbs_inline, rspec) shared across the sibling repositories.

- Add `rubocop-rspec` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure `RSpec/ExampleLength` and `RSpec/NamedSubject` with the same settings used across the sibling repositories
- Use an explicit `expect(subject)` instead of the implicit subject inside named examples (`RSpec/ImplicitSubject`)
- Use `described_class` in the `include` (`RSpec/DescribedClass`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)