### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 3.3
 
 plugins:
@@ -7,9 +10,45 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
-Style/Documentation:
+# Layout
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
+
+Layout/LineLength:
+  Max: 120
+
+# Metrics
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/MethodLength:
+  Max: 30
+
+# RSpec
+RSpec/ExampleLength:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
+
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -19,33 +58,24 @@ Style/RbsInline/RedundantTypeAnnotation:
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
 
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/RedundantFormat:
+  Enabled: false
+
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
-  Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/BlockLength:
-  Exclude:
-    - "spec/**/*_spec.rb"
-
-Layout/LeadingCommentSpace:
-  AllowRBSInlineAnnotation: true
-  AllowSteepAnnotation: true
-
-Layout/LineLength:
-  Max: 120
-
-Layout/MethodLength:
-  Max: 20
-
-Metrics/AbcSize:
-  Max: 20
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/NamedSubject:
-  Enabled: false

--- a/lib/rbs_shrine/rake_task.rb
+++ b/lib/rbs_shrine/rake_task.rb
@@ -9,7 +9,7 @@ module RbsShrine
 
     # @rbs name: Symbol
     # @rbs &block: ?(RakeTask) -> void
-    def initialize(name = :'rbs:shrine', &block) #: void
+    def initialize(name = :"rbs:shrine", &block) #: void
       super()
 
       @name = name

--- a/rbs_shrine.gemspec
+++ b/rbs_shrine.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- **Fix invalid cop names**: `Layout/BlockLength` → `Metrics/BlockLength`
  and `Layout/MethodLength` → `Metrics/MethodLength`. The `Layout/*` names
  do not exist, so those settings previously had no effect.
- Fill in missing cops: `AllCops/NewCops`, `Metrics/ClassLength`,
  `RSpec/MultipleMemoizedHelpers`, `RSpec/MultipleExpectations`,
  `RSpec/NestedGroups`, `Style/AccessorGrouping`, `Style/CommentedKeyword`,
  `Style/HashSyntax`
- `Metrics/MethodLength`: 20 → 30 (match baseline)
- Rules sorted in ASCII order to match the skeleton

## Code changes (offenses surfaced by the new cops)

- `rake_task.rb`: use a double-quoted symbol; `rbs_shrine.gemspec`: set
  `rubygems_mfa_required`
- Disable `Style/RedundantFormat`: the local `format` method is not
  `Kernel#format`, so the cop is a false positive here

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)