### PR TITLE
Introduce rubocop-rspec-unused-let

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ plugins:
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec
+  - rubocop-rspec-unused-let
 
 # Layout
 Layout/LeadingCommentSpace:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
 gem "rubocop-rspec"
+gem "rubocop-rspec-unused-let"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,10 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
+    rubocop-rspec-unused-let (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72)
+      rubocop-rspec (~> 3.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     shrine (3.9.0)
@@ -246,6 +250,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec
+  rubocop-rspec-unused-let
   steep
 
 BUNDLED WITH


### PR DESCRIPTION
Adds [rubocop-rspec-unused-let](https://github.com/tk0miya/rubocop-rspec-unused-let) and enables its `RSpec/UnusedLet` cop, which flags `let`/`subject` definitions and helper methods that are never referenced.

This repository's spec suite is already clean under the cop, so no code changes are needed — `bundle exec rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)